### PR TITLE
Fix task names in documentation

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,9 +5,9 @@
  Freebox Revolution & Freebox 4K are supported for the following stats:
  - traffic,
  - temp,
- - fan_speed,
+ - fan-speed,
  - xdsl,
- - xdsl_errors,
+ - xdsl-errors,
  - switch1,
  - switch2,
  - switch3,

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@
  - traffic,
  - temp,
  - fan-speed,
+ - hddspin,
  - xdsl,
  - xdsl-errors,
  - switch1,

--- a/main.py
+++ b/main.py
@@ -13,8 +13,8 @@
  - switch3,
  - switch4,
  - df
- - transmission_tasks
- - transmission_traffic """
+ - transmission-tasks
+ - transmission-traffic """
 
 import argparse
 import sys


### PR DESCRIPTION
The documentation indicates '_' but the code uses '-'.