### PR TITLE
main.py: use Python3

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """ This script provides munin scripts for Freebox OS stats.


### PR DESCRIPTION
I agree if you reject this patch.
I use Python3 on my side and would like this patch to be upstream so I do not have to carry it on my side.